### PR TITLE
update jenkins APT repository GPG key url

### DIFF
--- a/solution_template/scripts/install_jenkins.sh
+++ b/solution_template/scripts/install_jenkins.sh
@@ -279,7 +279,7 @@ EOF
 )
 
 #update apt repositories
-wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | sudo apt-key add -
+wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
 
 if [ "$jenkins_release_type" == "weekly" ]; then
   sudo sh -c 'echo deb http://pkg.jenkins.io/debian binary/ > /etc/apt/sources.list.d/jenkins.list'


### PR DESCRIPTION
GPG key has been update the 16th of April 2020
https://pkg.jenkins.io/debian-stable/